### PR TITLE
Pass feedback block to ephemeral sessions

### DIFF
--- a/cmd/vee/ephemeral.go
+++ b/cmd/vee/ephemeral.go
@@ -77,7 +77,7 @@ func dockerfilePath(cfg *EphemeralConfig) string {
 // buildEphemeralShellCmd constructs the full shell command for an ephemeral Docker session:
 //
 //	printf '\033[?25h'; docker build -t <tag> -f .vee/Dockerfile . && docker run --rm -it ... ; vee _session-ended ...
-func buildEphemeralShellCmd(cfg *EphemeralConfig, sessionID string, mode Mode, projectConfig, identityRule, platformsRule, prompt string, port int, veePath, veeBinary string, passthrough []string) string {
+func buildEphemeralShellCmd(cfg *EphemeralConfig, sessionID string, mode Mode, projectConfig, identityRule, platformsRule, feedbackBlock, prompt string, port int, veePath, veeBinary string, passthrough []string) string {
 	tag := ephemeralImageTag()
 	df := dockerfilePath(cfg)
 
@@ -93,7 +93,7 @@ func buildEphemeralShellCmd(cfg *EphemeralConfig, sessionID string, mode Mode, p
 
 	// Build the claude CLI arguments (system prompt + session ID + MCP + settings)
 	var claudeArgs []string
-	fullPrompt := composeSystemPrompt(mode.Prompt, identityRule, platformsRule, "", projectConfig, true)
+	fullPrompt := composeSystemPrompt(mode.Prompt, identityRule, platformsRule, feedbackBlock, projectConfig, true)
 	claudeArgs = buildArgs(passthrough, fullPrompt)
 	claudeArgs = append(claudeArgs, "--session-id", sessionID)
 	if mcpConfigFile != "" {

--- a/cmd/vee/main.go
+++ b/cmd/vee/main.go
@@ -357,7 +357,7 @@ func (cmd *NewPaneCmd) Run(args claudeArgs) error {
 		if cfg.Ephemeral == nil {
 			return fmt.Errorf("no [ephemeral] section in .vee/config")
 		}
-		shellCmd = buildEphemeralShellCmd(cfg.Ephemeral, sessionID, mode, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, cmd.Prompt, cmd.Port, cmd.VeePath, veeBinary, []string(args))
+		shellCmd = buildEphemeralShellCmd(cfg.Ephemeral, sessionID, mode, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, feedbackBlock, cmd.Prompt, cmd.Port, cmd.VeePath, veeBinary, []string(args))
 	} else {
 		sessionArgs := buildSessionArgs(sessionID, false, mode, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, feedbackBlock, cmd.Port, cmd.VeePath, []string(args), veeBinary)
 		shellCmd = buildWindowShellCmd(veeBinary, cmd.Port, sessionID, sessionArgs, cmd.Prompt)


### PR DESCRIPTION
## Summary

- `buildEphemeralShellCmd` was recomposing the system prompt with an empty feedback block instead of forwarding the one already fetched by the caller
- This meant ephemeral sessions never received sampled feedback examples (e.g., KB usage examples)

## Test plan

- [x] Start an ephemeral session and verify feedback examples appear in the composed system prompt