### PR TITLE
Fix plugin install nesting when target exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 install: build
 	install -d $(BINDIR)
 	install -m 755 vee $(BINDIR)/vee
+	rm -rf $(DATADIR)/plugins/vee
 	install -d $(DATADIR)/plugins
 	cp -r plugins/vee $(DATADIR)/plugins/vee
 	install -d $(DATADIR)/modes


### PR DESCRIPTION
## Summary

- `make install` nested the vee plugin as `plugins/vee/vee/...` when `~/.local/share/vee/plugins/vee` already existed, because `cp -r` copies *into* an existing directory rather than replacing it.
- Added `rm -rf` before the copy to ensure a clean slate on each install.

## Test plan

- [x] Run `make install` twice in a row; verify `~/.local/share/vee/plugins/vee` contains the expected structure without extra nesting.