### PR TITLE
Add startupScript option for ephemeral sessions

### DIFF
--- a/cmd/vee/config.go
+++ b/cmd/vee/config.go
@@ -268,6 +268,12 @@ func hydrateProjectConfig(m map[string][]string) *ProjectConfig {
 		}
 		cfg.Ephemeral.Compose = compose
 	}
+	if ss := lastValue(m, "ephemeral.startupscript"); ss != "" {
+		if cfg.Ephemeral == nil {
+			cfg.Ephemeral = &EphemeralConfig{}
+		}
+		cfg.Ephemeral.StartupScript = ss
+	}
 	if envs := m["ephemeral.env"]; len(envs) > 0 {
 		if cfg.Ephemeral == nil {
 			cfg.Ephemeral = &EphemeralConfig{}

--- a/cmd/vee/main.go
+++ b/cmd/vee/main.go
@@ -373,7 +373,10 @@ func (cmd *NewPaneCmd) Run(args claudeArgs) error {
 				return fmt.Errorf("compose validation failed: %w", err)
 			}
 		}
-		shellCmd = buildEphemeralShellCmd(cfg.Ephemeral, sessionID, profile, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, feedbackBlock, composeContents, cmd.Prompt, cmd.Port, cmd.VeePath, veeBinary, []string(args))
+		shellCmd, err = buildEphemeralShellCmd(cfg.Ephemeral, sessionID, profile, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, feedbackBlock, composeContents, cmd.Prompt, cmd.Port, cmd.VeePath, veeBinary, []string(args))
+		if err != nil {
+			return fmt.Errorf("ephemeral session: %w", err)
+		}
 	} else {
 		sessionArgs := buildSessionArgs(sessionID, false, profile, appCfg.ProjectConfig, appCfg.IdentityRule, appCfg.PlatformsRule, feedbackBlock, cmd.Port, cmd.VeePath, []string(args), veeBinary)
 		shellCmd = buildWindowShellCmd(veeBinary, cmd.Port, sessionID, sessionArgs, cmd.Prompt)


### PR DESCRIPTION
## Summary

- Add `startupScript` config option under `[ephemeral]` that mounts a user-provided shell script into the container and runs it before Claude starts.
- The script path is resolved relative to `.vee/` and bound read-only to `/opt/startup.sh`. Invoked via `sh` so no `chmod +x` is needed.
- A failing script prevents Claude from launching (the `&&` chain stops before `exec "$@"`).

## Config syntax

```ini
[ephemeral]
  startupScript = setup.sh
```

Resolves to `.vee/setup.sh`.

## Test plan

- [x] Add `startupScript = setup.sh` to `.vee/config` and create `.vee/setup.sh` with e.g. `echo "startup ok" > /tmp/startup-ran`
- [x] Start an ephemeral session and verify the script ran before Claude
- [x] Test with a failing script (`exit 1`) — Claude should not start
- [x] Test without `startupScript` configured — no behavioral change
- [x] Test with both overlay mounts and startup script — both should work