### PR TITLE
Add CI-built devenv image with nightly rebuild

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,0 +1,40 @@
+name: Build devenv image
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # nightly at 04:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - ".vee/Dockerfile.ci"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .vee/Dockerfile.ci
+          push: true
+          tags: |
+            ghcr.io/lthms/vee:devenv
+            ghcr.io/lthms/vee:devenv-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.vee/Dockerfile
+++ b/.vee/Dockerfile
@@ -1,11 +1,9 @@
-FROM debian:trixie-slim
+FROM ghcr.io/lthms/vee:devenv
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates git jq gh golang-go make \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-ENV PATH="/root/.local/bin:${PATH}"
+# Cache-bust: Docker re-fetches this URL on every build.
+# If main has new commits, the JSON changes -> git pull runs.
+# If no new commits, layer cache is reused -> instant build.
+ADD https://api.github.com/repos/lthms/vee/git/refs/heads/main /tmp/vee-ref.json
+RUN git -C /workspace pull --ff-only && go -C /workspace mod download
 
 WORKDIR /workspace

--- a/.vee/Dockerfile.ci
+++ b/.vee/Dockerfile.ci
@@ -1,0 +1,20 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git jq gh golang-go make \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Pre-clone the Vee repo so sessions start with source ready
+RUN git clone https://github.com/lthms/vee.git /workspace
+
+WORKDIR /workspace
+
+# Pre-warm Go module cache
+RUN go mod download
+
+# Configure git to use gh for auth (token provided at runtime via mounted ~/.config/gh)
+RUN git config --global credential.https://github.com.helper '!gh auth token'


### PR DESCRIPTION
## Summary

- Split `.vee/Dockerfile` into a **CI-built base image** (`.vee/Dockerfile.ci`) pushed to GHCR, and a **thin local wrapper** (`.vee/Dockerfile`) that extends it
- Added `.github/workflows/devenv.yml` for nightly builds, push-triggered rebuilds, and manual dispatch
- Session startup `docker build` becomes near-instant: the heavy work (apt-get, Claude Code install, repo clone, Go module download) is done once in CI

### How it works

**CI image** (`ghcr.io/lthms/vee:devenv`):
- Full Debian trixie-slim with all deps installed
- Vee repo pre-cloned in `/workspace`
- Go module cache pre-warmed
- Git credential helper configured for `gh`

**Local Dockerfile** (used by `vee` at session start):
- `FROM ghcr.io/lthms/vee:devenv`
- Uses `ADD <github-api-url>` to cache-bust: checks if `main` has new commits (~100ms)
- If `main` moved → `git pull --ff-only` + `go mod download` (a few seconds)
- If unchanged → all layers cached, build is instant

### Post-merge steps

1. Use `workflow_dispatch` to trigger the first CI build before the thin Dockerfile is active
2. Toggle the GHCR package to **public** if needed (GitHub UI)

## Test plan

- [ ] After CI runs: `docker pull ghcr.io/lthms/vee:devenv` succeeds
- [ ] Start a Vee ephemeral session — `docker build` completes quickly
- [ ] Inside the container: `/workspace` has the Vee repo with full git history
- [ ] `go build ./cmd/vee` skips module downloads
- [ ] `git push` and `gh pr create` work via mounted gh auth