### PR TITLE
Add Compose config field, validation, and helpers

### DIFF
--- a/cmd/vee/config.go
+++ b/cmd/vee/config.go
@@ -262,6 +262,12 @@ func hydrateProjectConfig(m map[string][]string) *ProjectConfig {
 		}
 		cfg.Ephemeral.Dockerfile = df
 	}
+	if compose := lastValue(m, "ephemeral.compose"); compose != "" {
+		if cfg.Ephemeral == nil {
+			cfg.Ephemeral = &EphemeralConfig{}
+		}
+		cfg.Ephemeral.Compose = compose
+	}
 	if envs := m["ephemeral.env"]; len(envs) > 0 {
 		if cfg.Ephemeral == nil {
 			cfg.Ephemeral = &EphemeralConfig{}

--- a/cmd/vee/config_test.go
+++ b/cmd/vee/config_test.go
@@ -321,6 +321,38 @@ func TestHydrateProjectConfig(t *testing.T) {
 	}
 }
 
+func TestHydrateProjectConfigCompose(t *testing.T) {
+	m := map[string][]string{
+		"ephemeral.dockerfile": {"Dockerfile"},
+		"ephemeral.compose":    {"docker-compose.yml"},
+	}
+
+	cfg := hydrateProjectConfig(m)
+	if cfg.Ephemeral == nil {
+		t.Fatal("expected non-nil Ephemeral")
+	}
+	if cfg.Ephemeral.Compose != "docker-compose.yml" {
+		t.Errorf("Compose = %q, want %q", cfg.Ephemeral.Compose, "docker-compose.yml")
+	}
+	if cfg.Ephemeral.Dockerfile != "Dockerfile" {
+		t.Errorf("Dockerfile = %q, want %q", cfg.Ephemeral.Dockerfile, "Dockerfile")
+	}
+}
+
+func TestHydrateProjectConfigComposeOnly(t *testing.T) {
+	m := map[string][]string{
+		"ephemeral.compose": {"compose.yml"},
+	}
+
+	cfg := hydrateProjectConfig(m)
+	if cfg.Ephemeral == nil {
+		t.Fatal("expected non-nil Ephemeral")
+	}
+	if cfg.Ephemeral.Compose != "compose.yml" {
+		t.Errorf("Compose = %q, want %q", cfg.Ephemeral.Compose, "compose.yml")
+	}
+}
+
 func TestHydrateUserConfig(t *testing.T) {
 	m := map[string][]string{
 		"embedding.model":      {"mxbai-embed-large"},

--- a/cmd/vee/ephemeral_test.go
+++ b/cmd/vee/ephemeral_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestComposeProjectName(t *testing.T) {
+	tests := []struct {
+		sessionID string
+		want      string
+	}{
+		{"abc123", "vee-abc123"},
+		{"550e8400-e29b-41d4-a716-446655440000", "vee-550e8400-e29b-41d4-a716-446655440000"},
+	}
+
+	// Compose project names must match [a-z0-9][a-z0-9_-]*
+	composeSafe := regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+	for _, tt := range tests {
+		t.Run(tt.sessionID, func(t *testing.T) {
+			got := composeProjectName(tt.sessionID)
+			if got != tt.want {
+				t.Errorf("composeProjectName(%q) = %q, want %q", tt.sessionID, got, tt.want)
+			}
+			if !composeSafe.MatchString(got) {
+				t.Errorf("composeProjectName(%q) = %q is not Compose-safe", tt.sessionID, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #8

## Summary
- Add `Compose` field to `EphemeralConfig` and hydrate it from `ephemeral.compose` in `.vee/config`
- Introduce `validateComposeFile()` (runs `docker compose config` as a preflight), `composeProjectName()` (derives a Compose-safe project name from the session ID), and `composePath()` (resolves the compose file path relative to `.vee/`)
- Extend `ephemeralAvailable()` to verify `docker compose` is usable when compose is configured

## Test plan
- `TestHydrateProjectConfigCompose` — asserts that `hydrateProjectConfig` with `ephemeral.compose = docker-compose.yml` populates `cfg.Ephemeral.Compose`
- `TestHydrateProjectConfigComposeOnly` — asserts compose-only config (no dockerfile) works
- `TestComposeProjectName` — asserts the output format (`vee-<sessionID>`) and that characters are Compose-safe
- `go test ./cmd/vee/...` — all existing tests pass (regression check)