### PR TITLE
Add project-local profile discovery

### DIFF
--- a/cmd/vee/profiles.go
+++ b/cmd/vee/profiles.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -90,11 +91,13 @@ func loadProfilesFromDir(dir string) ([]Profile, error) {
 		}
 		content, err := os.ReadFile(filepath.Join(dir, e.Name()))
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+			slog.Warn("skipping unreadable profile", "file", e.Name(), "error", err)
+			continue
 		}
 		profile, err := parseProfileFile(e.Name(), content)
 		if err != nil {
-			return nil, err
+			slog.Warn("skipping malformed profile", "file", e.Name(), "error", err)
+			continue
 		}
 		profiles = append(profiles, profile)
 	}


### PR DESCRIPTION
## Summary
- Make `loadProfilesFromDir` skip malformed profile files instead of aborting, with warning logs
- Add project-local profile discovery from `.vee/profiles/` in the current working directory

Profiles are now merged from three directories (later wins):
1. `veePath/profiles/` — installed defaults
2. `~/.config/vee/profiles/` — user overrides
3. `.vee/profiles/` — project-local overrides

## Test plan
- [x] Main build compiles
- [x] Added test for project-local profile merging
- [ ] Manual test: create `.vee/profiles/custom.md` in a project and verify it appears in the picker