### PR TITLE
Add kb_forget and scope to knowledge base

### DIFF
--- a/cmd/vee/daemon.go
+++ b/cmd/vee/daemon.go
@@ -41,6 +41,10 @@ type kbTouchArgs struct {
 	ID string `json:"id" jsonschema:"Statement ID (as returned by kb_query)"`
 }
 
+type kbForgetArgs struct {
+	ID string `json:"id" jsonschema:"Statement ID to flag for deletion (as returned by kb_query)"`
+}
+
 type feedbackRecordArgs struct {
 	Kind      string `json:"kind" jsonschema:"Whether this is a good or bad example (good or bad)"`
 	Statement string `json:"statement" jsonschema:"The example or counter-example statement"`
@@ -141,6 +145,22 @@ func newMCPServer(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store, ses
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: fmt.Sprintf("Touched: %s (last_verified updated to today)", args.ID)},
+			},
+		}, nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "kb_forget",
+		Description: "Flag a statement for deletion. Hidden from queries, pending user review.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args kbForgetArgs) (*mcp.CallToolResult, any, error) {
+		slog.Debug("kb_forget called", "id", args.ID)
+		if err := kbase.FlagStatement(args.ID); err != nil {
+			return nil, nil, fmt.Errorf("kb_forget: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Flagged for deletion: %s (pending user review)", args.ID)},
 			},
 		}, nil, nil
 	})

--- a/cmd/vee/daemon.go
+++ b/cmd/vee/daemon.go
@@ -31,6 +31,7 @@ type kbRememberArgs struct {
 	Content    string `json:"content" jsonschema:"The statement to save. Must be a single atomic fact (max 2000 chars)."`
 	Source     string `json:"source" jsonschema:"Origin of the information (file path, URL, issue reference, etc.)"`
 	SourceType string `json:"source_type,omitempty" jsonschema:"Type of source (default: manual)"`
+	Scope      string `json:"scope,omitempty" jsonschema:"Scope: user (all projects) or project (this project only). Default: user"`
 }
 
 type kbQueryArgs struct {
@@ -99,16 +100,34 @@ func newMCPServer(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store, ses
 	// Knowledge base tools — available to all profiles
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "kb_remember",
-		Description: "Save a statement to the persistent knowledge base. The statement is queued for async duplicate detection and will be promoted to active once processed.",
+		Description: "Save a fact to your long-term memory. Use this whenever you learn something useful: build commands, project conventions, user preferences, architectural decisions. One atomic fact per call. Will be deduplicated automatically.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args kbRememberArgs) (*mcp.CallToolResult, any, error) {
 		slog.Debug("kb_remember called")
 
-		result, err := kbase.AddStatement(args.Content, args.Source, args.SourceType)
+		scope := args.Scope
+		if scope == "" {
+			scope = "user"
+		}
+		if scope != "user" && scope != "project" {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "scope must be 'user' or 'project'"},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+
+		project := ""
+		if scope == "project" {
+			project, _ = os.Getwd()
+		}
+
+		result, err := kbase.AddStatement(args.Content, args.Source, args.SourceType, scope, project)
 		if err != nil {
 			return nil, nil, fmt.Errorf("kb_remember: %w", err)
 		}
 
-		msg := fmt.Sprintf("Statement saved (id: %s, status: pending — will be promoted after duplicate check)", result.ID)
+		msg := fmt.Sprintf("Statement saved (id: %s, scope: %s, status: pending — will be promoted after duplicate check)", result.ID, scope)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -119,10 +138,11 @@ func newMCPServer(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store, ses
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "kb_query",
-		Description: "Search the knowledge base using semantic similarity. Returns matching statements with scores. Use specific search terms, not wildcards.",
+		Description: "Search your long-term memory. Query BEFORE starting unfamiliar tasks — past sessions may have already solved this. Use specific terms like 'vee build commands' not vague phrases. Empty results = opportunity to learn and remember.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args kbQueryArgs) (*mcp.CallToolResult, any, error) {
 		slog.Debug("kb_query called", "query", args.Query)
-		results, err := kbase.Query(args.Query)
+		project, _ := os.Getwd()
+		results, err := kbase.Query(args.Query, project)
 		if err != nil {
 			return nil, nil, fmt.Errorf("kb_query: %w", err)
 		}
@@ -135,7 +155,7 @@ func newMCPServer(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store, ses
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "kb_touch",
-		Description: "Bump the last_verified timestamp of a statement to today, confirming the information is still accurate. Use IDs returned by kb_query.",
+		Description: "Confirm a statement is still accurate. Call this when you use information from kb_query and verify it's correct. Keeps the knowledge base healthy by tracking freshness.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args kbTouchArgs) (*mcp.CallToolResult, any, error) {
 		slog.Debug("kb_touch called", "id", args.ID)
 		if err := kbase.TouchStatement(args.ID); err != nil {
@@ -151,7 +171,7 @@ func newMCPServer(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store, ses
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "kb_forget",
-		Description: "Flag a statement for deletion. Hidden from queries, pending user review.",
+		Description: "Flag outdated or incorrect information for removal. Use when you discover a kb_query result is wrong or obsolete. Hidden immediately, queued for user to confirm deletion.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args kbForgetArgs) (*mcp.CallToolResult, any, error) {
 		slog.Debug("kb_forget called", "id", args.ID)
 		if err := kbase.FlagStatement(args.ID); err != nil {
@@ -771,7 +791,7 @@ func (cmd *DaemonCmd) Run() error {
 }
 
 // handleKBQuery handles GET /api/kb/query?q=<query>.
-// Returns a JSON array of QueryResult objects.
+// Returns a JSON array of QueryResult objects. Uses daemon's working directory for project scope.
 func handleKBQuery(kbase *kb.KnowledgeBase) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -785,7 +805,10 @@ func handleKBQuery(kbase *kb.KnowledgeBase) http.HandlerFunc {
 			return
 		}
 
-		results, err := kbase.Query(query)
+		// Default to current working directory for project scope filtering
+		project, _ := os.Getwd()
+
+		results, err := kbase.Query(query, project)
 		if err != nil {
 			http.Error(w, "query failed: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/cmd/vee/daemon.go
+++ b/cmd/vee/daemon.go
@@ -243,6 +243,9 @@ func setupHTTPMux(app *App, kbase *kb.KnowledgeBase, fstore *feedback.Store) *ht
 	mux.HandleFunc("/api/kb/fetch", handleKBFetch(kbase))
 	mux.HandleFunc("/api/kb/issues", handleKBIssues(kbase))
 	mux.HandleFunc("/api/kb/issues/resolve", handleKBIssueResolve(kbase))
+	mux.HandleFunc("/api/kb/flagged", handleKBFlagged(kbase))
+	mux.HandleFunc("/api/kb/flagged/confirm", handleKBFlaggedConfirm(kbase))
+	mux.HandleFunc("/api/kb/flagged/restore", handleKBFlaggedRestore(kbase))
 	if fstore != nil {
 		mux.HandleFunc("/api/feedback/sample", handleFeedbackSample(fstore, app))
 	}
@@ -877,6 +880,77 @@ func handleKBIssueResolve(kbase *kb.KnowledgeBase) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "resolved"})
+	}
+}
+
+// handleKBFlagged handles GET /api/kb/flagged — returns all flagged statements.
+func handleKBFlagged(kbase *kb.KnowledgeBase) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		flagged, err := kbase.ListFlaggedStatements()
+		if err != nil {
+			http.Error(w, "list flagged: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if flagged == nil {
+			flagged = []kb.FlaggedStatement{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(flagged)
+	}
+}
+
+// handleKBFlaggedConfirm handles POST /api/kb/flagged/confirm?id=<id> — deletes flagged statement.
+func handleKBFlaggedConfirm(kbase *kb.KnowledgeBase) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		id := r.URL.Query().Get("id")
+		if id == "" {
+			http.Error(w, "missing id query parameter", http.StatusBadRequest)
+			return
+		}
+
+		if err := kbase.DeleteStatement(id); err != nil {
+			http.Error(w, "delete: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	}
+}
+
+// handleKBFlaggedRestore handles POST /api/kb/flagged/restore?id=<id> — restores flagged statement.
+func handleKBFlaggedRestore(kbase *kb.KnowledgeBase) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		id := r.URL.Query().Get("id")
+		if id == "" {
+			http.Error(w, "missing id query parameter", http.StatusBadRequest)
+			return
+		}
+
+		if err := kbase.RestoreStatement(id); err != nil {
+			http.Error(w, "restore: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "restored"})
 	}
 }
 

--- a/cmd/vee/issue_resolver.go
+++ b/cmd/vee/issue_resolver.go
@@ -32,16 +32,31 @@ type resolverIssue struct {
 	SourceB    string  `json:"source_b"`
 }
 
+// resolverFlagged mirrors kb.FlaggedStatement for JSON decoding.
+type resolverFlagged struct {
+	ID        string `json:"id"`
+	Content   string `json:"content"`
+	Source    string `json:"source"`
+	FlaggedAt string `json:"flagged_at"`
+}
+
 const (
 	resolverStateList   = 0
 	resolverStateDetail = 1
+)
+
+const (
+	resolverTabIssues  = 0
+	resolverTabFlagged = 1
 )
 
 type resolverState struct {
 	port int
 
 	state    int // resolverStateList or resolverStateDetail
+	tab      int // resolverTabIssues or resolverTabFlagged
 	issues   []resolverIssue
+	flagged  []resolverFlagged
 	selected int
 	message  string // transient status message
 
@@ -78,6 +93,7 @@ func (cmd *IssueResolverCmd) Run() error {
 	}
 
 	rs.fetchIssues()
+	rs.fetchFlagged()
 	rs.render()
 
 	inputCh := make(chan []byte, 1)
@@ -122,22 +138,44 @@ func (rs *resolverState) handleListInput(input []byte) bool {
 		switch input[0] {
 		case 'q', 27: // q or Esc
 			return true
+		case 9: // Tab — switch tabs
+			rs.switchTab()
 		case 10, 13: // Enter — open detail
-			if len(rs.issues) > 0 && rs.selected >= 0 && rs.selected < len(rs.issues) {
-				rs.openDetail()
+			if rs.tab == resolverTabIssues {
+				if len(rs.issues) > 0 && rs.selected >= 0 && rs.selected < len(rs.issues) {
+					rs.openDetail()
+				}
+			} else {
+				if len(rs.flagged) > 0 && rs.selected >= 0 && rs.selected < len(rs.flagged) {
+					rs.openFlaggedDetail()
+				}
 			}
 		case 'j':
 			rs.moveSelection(1)
 		case 'k':
 			rs.moveSelection(-1)
 		case 'a':
-			rs.resolveSelected("keep_a")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_a")
+			}
 		case 'b':
-			rs.resolveSelected("keep_b")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_b")
+			}
 		case 'K':
-			rs.resolveSelected("keep_both")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_both")
+			}
 		case 'd':
-			rs.resolveSelected("delete_both")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("delete_both")
+			} else {
+				rs.confirmFlagged()
+			}
+		case 'r':
+			if rs.tab == resolverTabFlagged {
+				rs.restoreFlagged()
+			}
 		}
 	} else if len(input) == 3 && input[0] == 27 && input[1] == 91 {
 		switch input[2] {
@@ -145,6 +183,10 @@ func (rs *resolverState) handleListInput(input []byte) bool {
 			rs.moveSelection(-1)
 		case 66: // Down
 			rs.moveSelection(1)
+		case 67: // Right
+			rs.switchTab()
+		case 68: // Left
+			rs.switchTab()
 		}
 	} else if len(input) == 2 && input[0] == 27 {
 		return true
@@ -166,13 +208,27 @@ func (rs *resolverState) handleDetailInput(input []byte) bool {
 		case 'k':
 			rs.scrollDetail(-1)
 		case 'a':
-			rs.resolveSelected("keep_a")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_a")
+			}
 		case 'b':
-			rs.resolveSelected("keep_b")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_b")
+			}
 		case 'K':
-			rs.resolveSelected("keep_both")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("keep_both")
+			}
 		case 'd':
-			rs.resolveSelected("delete_both")
+			if rs.tab == resolverTabIssues {
+				rs.resolveSelected("delete_both")
+			} else {
+				rs.confirmFlagged()
+			}
+		case 'r':
+			if rs.tab == resolverTabFlagged {
+				rs.restoreFlagged()
+			}
 		}
 	} else if len(input) == 3 && input[0] == 27 && input[1] == 91 {
 		switch input[2] {
@@ -188,16 +244,31 @@ func (rs *resolverState) handleDetailInput(input []byte) bool {
 }
 
 func (rs *resolverState) moveSelection(delta int) {
-	if len(rs.issues) == 0 {
+	var maxIdx int
+	if rs.tab == resolverTabIssues {
+		maxIdx = len(rs.issues)
+	} else {
+		maxIdx = len(rs.flagged)
+	}
+	if maxIdx == 0 {
 		return
 	}
 	rs.selected += delta
 	if rs.selected < 0 {
 		rs.selected = 0
 	}
-	if rs.selected >= len(rs.issues) {
-		rs.selected = len(rs.issues) - 1
+	if rs.selected >= maxIdx {
+		rs.selected = maxIdx - 1
 	}
+}
+
+func (rs *resolverState) switchTab() {
+	if rs.tab == resolverTabIssues {
+		rs.tab = resolverTabFlagged
+	} else {
+		rs.tab = resolverTabIssues
+	}
+	rs.selected = 0
 }
 
 func (rs *resolverState) scrollDetail(delta int) {
@@ -229,11 +300,38 @@ func (rs *resolverState) fetchIssues() {
 	}
 
 	rs.issues = issues
-	if rs.selected >= len(rs.issues) {
-		rs.selected = len(rs.issues) - 1
+	if rs.tab == resolverTabIssues {
+		if rs.selected >= len(rs.issues) {
+			rs.selected = len(rs.issues) - 1
+		}
+		if rs.selected < 0 {
+			rs.selected = 0
+		}
 	}
-	if rs.selected < 0 {
-		rs.selected = 0
+}
+
+func (rs *resolverState) fetchFlagged() {
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/kb/flagged", rs.port))
+	if err != nil {
+		rs.flagged = nil
+		return
+	}
+	defer resp.Body.Close()
+
+	var flagged []resolverFlagged
+	if err := json.NewDecoder(resp.Body).Decode(&flagged); err != nil {
+		rs.flagged = nil
+		return
+	}
+
+	rs.flagged = flagged
+	if rs.tab == resolverTabFlagged {
+		if rs.selected >= len(rs.flagged) {
+			rs.selected = len(rs.flagged) - 1
+		}
+		if rs.selected < 0 {
+			rs.selected = 0
+		}
 	}
 }
 
@@ -291,6 +389,93 @@ func (rs *resolverState) openDetail() {
 	rs.state = resolverStateDetail
 }
 
+func (rs *resolverState) openFlaggedDetail() {
+	f := rs.flagged[rs.selected]
+
+	contentWidth := rs.termWidth - 8
+
+	var lines []string
+
+	// Flagged statement header
+	lines = append(lines, ansiOrange+ansiBold+"Flagged Statement"+ansiReset)
+	if f.Source != "" {
+		lines = append(lines, ansiMuted+"Source: "+f.Source+ansiReset)
+	}
+	lines = append(lines, ansiMuted+"Flagged: "+f.FlaggedAt+ansiReset)
+	lines = append(lines, "")
+
+	// Content
+	for _, line := range strings.Split(f.Content, "\n") {
+		if len(line) <= contentWidth {
+			lines = append(lines, renderInlineMarkdown(line))
+		} else {
+			for _, wrapped := range wrapLine(line, contentWidth) {
+				lines = append(lines, renderInlineMarkdown(wrapped))
+			}
+		}
+	}
+
+	rs.detailLines = lines
+	rs.detailScroll = 0
+	rs.state = resolverStateDetail
+}
+
+func (rs *resolverState) confirmFlagged() {
+	if len(rs.flagged) == 0 || rs.selected < 0 || rs.selected >= len(rs.flagged) {
+		return
+	}
+
+	f := rs.flagged[rs.selected]
+
+	resp, err := http.Post(
+		fmt.Sprintf("http://127.0.0.1:%d/api/kb/flagged/confirm?id=%s", rs.port, f.ID),
+		"application/json",
+		bytes.NewReader([]byte("{}")),
+	)
+	if err != nil {
+		rs.message = "Error: " + err.Error()
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		rs.message = fmt.Sprintf("Error: HTTP %d", resp.StatusCode)
+		return
+	}
+
+	rs.message = "Deleted"
+	rs.state = resolverStateList
+	rs.fetchFlagged()
+}
+
+func (rs *resolverState) restoreFlagged() {
+	if len(rs.flagged) == 0 || rs.selected < 0 || rs.selected >= len(rs.flagged) {
+		return
+	}
+
+	f := rs.flagged[rs.selected]
+
+	resp, err := http.Post(
+		fmt.Sprintf("http://127.0.0.1:%d/api/kb/flagged/restore?id=%s", rs.port, f.ID),
+		"application/json",
+		bytes.NewReader([]byte("{}")),
+	)
+	if err != nil {
+		rs.message = "Error: " + err.Error()
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		rs.message = fmt.Sprintf("Error: HTTP %d", resp.StatusCode)
+		return
+	}
+
+	rs.message = "Restored"
+	rs.state = resolverStateList
+	rs.fetchFlagged()
+}
+
 func (rs *resolverState) resolveSelected(action string) {
 	if len(rs.issues) == 0 || rs.selected < 0 || rs.selected >= len(rs.issues) {
 		return
@@ -337,18 +522,31 @@ func (rs *resolverState) render() {
 func (rs *resolverState) renderList(sb *strings.Builder) {
 	w := rs.termWidth
 
-	// Header
+	// Header with tabs
 	sb.WriteString("\r\n  ")
-	sb.WriteString(ansiAccent)
-	sb.WriteString(ansiBold)
-	sb.WriteString("Issue Resolver")
+
+	// Issues tab
+	if rs.tab == resolverTabIssues {
+		sb.WriteString(ansiAccent)
+		sb.WriteString(ansiBold)
+	} else {
+		sb.WriteString(ansiMuted)
+	}
+	sb.WriteString(fmt.Sprintf("Duplicates (%d)", len(rs.issues)))
 	sb.WriteString(ansiReset)
 
-	if len(rs.issues) > 0 {
+	sb.WriteString("  ")
+
+	// Flagged tab
+	if rs.tab == resolverTabFlagged {
+		sb.WriteString(ansiAccent)
+		sb.WriteString(ansiBold)
+	} else {
 		sb.WriteString(ansiMuted)
-		sb.WriteString(fmt.Sprintf("  %d open", len(rs.issues)))
-		sb.WriteString(ansiReset)
 	}
+	sb.WriteString(fmt.Sprintf("Flagged (%d)", len(rs.flagged)))
+	sb.WriteString(ansiReset)
+
 	sb.WriteString("\r\n\r\n")
 
 	// Status message
@@ -361,11 +559,19 @@ func (rs *resolverState) renderList(sb *strings.Builder) {
 		rs.message = ""
 	}
 
+	if rs.tab == resolverTabIssues {
+		rs.renderIssuesList(sb, w)
+	} else {
+		rs.renderFlaggedList(sb, w)
+	}
+}
+
+func (rs *resolverState) renderIssuesList(sb *strings.Builder, w int) {
 	if len(rs.issues) == 0 {
 		sb.WriteString("  ")
 		sb.WriteString(ansiMuted)
 		sb.WriteString(ansiItalic)
-		sb.WriteString("No open issues")
+		sb.WriteString("No duplicate issues")
 		sb.WriteString(ansiReset)
 		sb.WriteString("\r\n")
 	} else {
@@ -446,6 +652,10 @@ func (rs *resolverState) renderList(sb *strings.Builder) {
 	// Footer
 	sb.WriteString("\r\n  ")
 	sb.WriteString(ansiMuted)
+	sb.WriteString("Tab/←→")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" switch  ")
+	sb.WriteString(ansiMuted)
 	sb.WriteString("↑↓/jk")
 	sb.WriteString(ansiReset)
 	sb.WriteString(" navigate  ")
@@ -464,11 +674,108 @@ func (rs *resolverState) renderList(sb *strings.Builder) {
 	sb.WriteString(ansiMuted)
 	sb.WriteString("K")
 	sb.WriteString(ansiReset)
-	sb.WriteString(" keep both  ")
+	sb.WriteString(" both  ")
 	sb.WriteString(ansiMuted)
 	sb.WriteString("d")
 	sb.WriteString(ansiReset)
-	sb.WriteString(" delete both  ")
+	sb.WriteString(" delete  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("q")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" quit")
+	sb.WriteString("\r\n")
+}
+
+func (rs *resolverState) renderFlaggedList(sb *strings.Builder, w int) {
+	if len(rs.flagged) == 0 {
+		sb.WriteString("  ")
+		sb.WriteString(ansiMuted)
+		sb.WriteString(ansiItalic)
+		sb.WriteString("No flagged statements")
+		sb.WriteString(ansiReset)
+		sb.WriteString("\r\n")
+	} else {
+		// Calculate visible items
+		maxVisible := (rs.termHeight - 10) / 2
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+		if maxVisible > len(rs.flagged) {
+			maxVisible = len(rs.flagged)
+		}
+
+		start := 0
+		if rs.selected >= maxVisible {
+			start = rs.selected - maxVisible + 1
+		}
+		end := start + maxVisible
+		if end > len(rs.flagged) {
+			end = len(rs.flagged)
+			start = end - maxVisible
+			if start < 0 {
+				start = 0
+			}
+		}
+
+		for i := start; i < end; i++ {
+			f := rs.flagged[i]
+
+			// Selection indicator
+			if i == rs.selected {
+				sb.WriteString("  ")
+				sb.WriteString(ansiAccent)
+				sb.WriteString("▸")
+				sb.WriteString(ansiReset)
+				sb.WriteString(" ")
+			} else {
+				sb.WriteString("    ")
+			}
+
+			// Type badge
+			sb.WriteString(ansiOrange)
+			sb.WriteString("DEL")
+			sb.WriteString(ansiReset)
+
+			// Preview of content
+			preview := firstLine(f.Content)
+			maxPreview := w - 16
+			if maxPreview > 0 && len(preview) > maxPreview {
+				preview = preview[:maxPreview-3] + "..."
+			}
+			sb.WriteString("  ")
+			if i == rs.selected {
+				sb.WriteString(ansiBold)
+			}
+			sb.WriteString(preview)
+			if i == rs.selected {
+				sb.WriteString(ansiReset)
+			}
+			sb.WriteString("\r\n\r\n")
+		}
+	}
+
+	// Footer
+	sb.WriteString("\r\n  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("Tab/←→")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" switch  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("↑↓/jk")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" navigate  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("Enter")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" detail  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("d")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" confirm delete  ")
+	sb.WriteString(ansiMuted)
+	sb.WriteString("r")
+	sb.WriteString(ansiReset)
+	sb.WriteString(" restore  ")
 	sb.WriteString(ansiMuted)
 	sb.WriteString("q")
 	sb.WriteString(ansiReset)
@@ -507,28 +814,41 @@ func (rs *resolverState) renderDetail(sb *strings.Builder) {
 		sb.WriteString("\r\n")
 	}
 
-	// Footer
+	// Footer (tab-specific)
 	sb.WriteString("\r\n  ")
 	sb.WriteString(ansiMuted)
 	sb.WriteString("↑↓/jk")
 	sb.WriteString(ansiReset)
 	sb.WriteString(" scroll  ")
-	sb.WriteString(ansiMuted)
-	sb.WriteString("a")
-	sb.WriteString(ansiReset)
-	sb.WriteString(" keep A  ")
-	sb.WriteString(ansiMuted)
-	sb.WriteString("b")
-	sb.WriteString(ansiReset)
-	sb.WriteString(" keep B  ")
-	sb.WriteString(ansiMuted)
-	sb.WriteString("K")
-	sb.WriteString(ansiReset)
-	sb.WriteString(" keep both  ")
-	sb.WriteString(ansiMuted)
-	sb.WriteString("d")
-	sb.WriteString(ansiReset)
-	sb.WriteString(" delete both  ")
+
+	if rs.tab == resolverTabIssues {
+		sb.WriteString(ansiMuted)
+		sb.WriteString("a")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" keep A  ")
+		sb.WriteString(ansiMuted)
+		sb.WriteString("b")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" keep B  ")
+		sb.WriteString(ansiMuted)
+		sb.WriteString("K")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" keep both  ")
+		sb.WriteString(ansiMuted)
+		sb.WriteString("d")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" delete both  ")
+	} else {
+		sb.WriteString(ansiMuted)
+		sb.WriteString("d")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" confirm delete  ")
+		sb.WriteString(ansiMuted)
+		sb.WriteString("r")
+		sb.WriteString(ansiReset)
+		sb.WriteString(" restore  ")
+	}
+
 	sb.WriteString(ansiMuted)
 	sb.WriteString("Esc")
 	sb.WriteString(ansiReset)

--- a/cmd/vee/prompts/base.md
+++ b/cmd/vee/prompts/base.md
@@ -1,14 +1,40 @@
 <rule object="Knowledge base">
-You have access to a persistent knowledge base. Use it!
-ALWAYS access it via the MCP tool. NEVER try to bypass the MCP tool.
+You have access to a persistent knowledge base — your long-term memory across sessions.
+ALWAYS access it via MCP tools. NEVER bypass them.
 
-Use `kb_remember` to remember facts across sessions.
-NEVER mix several ideas in one statement.
-ALWAYS strive for conciseness.
+## Query First (`kb_query`)
 
-Use `kb_query` to fetch relevant statements via meaningful search terms.
-Explore the `source` of a statement ONLY IF that statement is useful
+**Before diving into unfamiliar territory, query the KB.** Past-you may have already solved this.
 
-Query results include a `last_verified` date.
-Use `kb_touch` for statements fetched via `kb_query` ONLY IF you have validated it.
+Use specific terms, not vague phrases:
+<example status="good">"vee build requirements"</example>
+<example status="good">"project authentication flow"</example>
+<example status="bad">"*" or "stuff" or "how to do things"</example>
+
+Use `kb_touch` when a result is still accurate — this keeps the KB healthy.
+
+**No results?** You're in uncharted territory. Pay attention: whatever you learn is worth saving.
+
+## Learn and Remember (`kb_remember`)
+
+When you discover something useful, **save it immediately** — don't wait until the end of the session.
+
+Good candidates:
+- Build commands, test patterns, project quirks
+- User preferences, workflow patterns
+- Architectural decisions and their rationale
+- API details, environment setup, gotchas
+
+**One fact per statement.** Be terse: "vee uses Go 1.22" not "The vee project is built using Go version 1.22".
+
+**Scope**:
+- `user` — applies everywhere (preferences, general knowledge)
+- `project` — only relevant here (project-specific conventions)
+
+## Prune Stale Knowledge (`kb_forget`)
+
+Found something outdated or wrong? Flag it with `kb_forget`.
+It's hidden immediately and queued for the user to confirm deletion.
+
+Don't let bad information linger — a clean KB is a useful KB.
 </rule>

--- a/internal/kb/issues.go
+++ b/internal/kb/issues.go
@@ -6,6 +6,38 @@ import (
 	"time"
 )
 
+// FlaggedStatement represents a statement flagged for deletion.
+type FlaggedStatement struct {
+	ID        string `json:"id"`
+	Content   string `json:"content"`
+	Source    string `json:"source"`
+	FlaggedAt string `json:"flagged_at"`
+}
+
+// ListFlaggedStatements returns all flagged statements, ordered by flag time descending.
+func (kb *KnowledgeBase) ListFlaggedStatements() ([]FlaggedStatement, error) {
+	rows, err := kb.db.Query(
+		`SELECT id, content, source, flagged_at
+		 FROM statements WHERE flagged_at != ''
+		 ORDER BY flagged_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list flagged statements: %w", err)
+	}
+	defer rows.Close()
+
+	var flagged []FlaggedStatement
+	for rows.Next() {
+		var f FlaggedStatement
+		if err := rows.Scan(&f.ID, &f.Content, &f.Source, &f.FlaggedAt); err != nil {
+			slog.Warn("list flagged: scan row", "error", err)
+			continue
+		}
+		flagged = append(flagged, f)
+	}
+	return flagged, rows.Err()
+}
+
 // Issue represents a detected issue between two statements.
 type Issue struct {
 	ID         string  `json:"id"`

--- a/internal/kb/kb_test.go
+++ b/internal/kb/kb_test.go
@@ -751,3 +751,413 @@ func TestIssue_DeleteBoth(t *testing.T) {
 		t.Error("expected D2 to be deleted")
 	}
 }
+
+// --- Flag/Restore tests ---
+
+func TestFlagStatement(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, _ := kbase.AddStatement("Flag me", "src", "manual", "", "")
+
+	err := kbase.FlagStatement(result.ID)
+	if err != nil {
+		t.Fatalf("FlagStatement: %v", err)
+	}
+
+	var flaggedAt string
+	kbase.db.QueryRow(`SELECT flagged_at FROM statements WHERE id = ?`, result.ID).Scan(&flaggedAt)
+	if flaggedAt == "" {
+		t.Error("expected flagged_at to be set")
+	}
+}
+
+func TestFlagStatement_NotFound(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	err := kbase.FlagStatement("nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent statement")
+	}
+}
+
+func TestFlagStatement_AlreadyFlagged(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, _ := kbase.AddStatement("Double flag me", "src", "manual", "", "")
+	kbase.FlagStatement(result.ID)
+
+	err := kbase.FlagStatement(result.ID)
+	if err == nil {
+		t.Fatal("expected error for already flagged statement")
+	}
+}
+
+func TestRestoreStatement(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, _ := kbase.AddStatement("Restore me", "src", "manual", "", "")
+	kbase.FlagStatement(result.ID)
+
+	err := kbase.RestoreStatement(result.ID)
+	if err != nil {
+		t.Fatalf("RestoreStatement: %v", err)
+	}
+
+	var flaggedAt string
+	kbase.db.QueryRow(`SELECT flagged_at FROM statements WHERE id = ?`, result.ID).Scan(&flaggedAt)
+	if flaggedAt != "" {
+		t.Errorf("expected flagged_at to be cleared, got %q", flaggedAt)
+	}
+}
+
+func TestRestoreStatement_NotFlagged(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, _ := kbase.AddStatement("Not flagged", "src", "manual", "", "")
+
+	err := kbase.RestoreStatement(result.ID)
+	if err == nil {
+		t.Fatal("expected error for non-flagged statement")
+	}
+}
+
+func TestRestoreStatement_NotFound(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	err := kbase.RestoreStatement("nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent statement")
+	}
+}
+
+// --- ListFlaggedStatements tests ---
+
+func TestListFlaggedStatements_Empty(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	flagged, err := kbase.ListFlaggedStatements()
+	if err != nil {
+		t.Fatalf("ListFlaggedStatements: %v", err)
+	}
+	if len(flagged) != 0 {
+		t.Errorf("expected no flagged statements, got %d", len(flagged))
+	}
+}
+
+func TestListFlaggedStatements_ReturnsFlagged(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	r1, _ := kbase.AddStatement("Flagged one", "src1", "manual", "", "")
+	kbase.AddStatement("Not flagged", "src2", "manual", "", "")
+	r3, _ := kbase.AddStatement("Flagged two", "src3", "manual", "", "")
+
+	kbase.FlagStatement(r1.ID)
+	kbase.FlagStatement(r3.ID)
+
+	flagged, err := kbase.ListFlaggedStatements()
+	if err != nil {
+		t.Fatalf("ListFlaggedStatements: %v", err)
+	}
+	if len(flagged) != 2 {
+		t.Errorf("expected 2 flagged statements, got %d", len(flagged))
+	}
+
+	for _, f := range flagged {
+		if f.ID == "" {
+			t.Error("expected non-empty ID")
+		}
+		if f.Content == "" {
+			t.Error("expected non-empty Content")
+		}
+		if f.FlaggedAt == "" {
+			t.Error("expected non-empty FlaggedAt")
+		}
+	}
+}
+
+// --- Scope tests ---
+
+func TestAddStatement_WithScope(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	r1, err := kbase.AddStatement("User statement", "src", "manual", "user", "")
+	if err != nil {
+		t.Fatalf("AddStatement(user): %v", err)
+	}
+
+	r2, err := kbase.AddStatement("Project statement", "src", "manual", "project", "my-project")
+	if err != nil {
+		t.Fatalf("AddStatement(project): %v", err)
+	}
+
+	var scope1, project1 string
+	kbase.db.QueryRow(`SELECT scope, project FROM statements WHERE id = ?`, r1.ID).Scan(&scope1, &project1)
+	if scope1 != "user" {
+		t.Errorf("expected scope 'user', got %q", scope1)
+	}
+	if project1 != "" {
+		t.Errorf("expected empty project, got %q", project1)
+	}
+
+	var scope2, project2 string
+	kbase.db.QueryRow(`SELECT scope, project FROM statements WHERE id = ?`, r2.ID).Scan(&scope2, &project2)
+	if scope2 != "project" {
+		t.Errorf("expected scope 'project', got %q", scope2)
+	}
+	if project2 != "my-project" {
+		t.Errorf("expected project 'my-project', got %q", project2)
+	}
+}
+
+func TestAddStatement_DefaultScope(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, err := kbase.AddStatement("Default scope", "src", "manual", "", "")
+	if err != nil {
+		t.Fatalf("AddStatement: %v", err)
+	}
+
+	var scope string
+	kbase.db.QueryRow(`SELECT scope FROM statements WHERE id = ?`, result.ID).Scan(&scope)
+	if scope != "user" {
+		t.Errorf("expected default scope 'user', got %q", scope)
+	}
+}
+
+// --- Query with scope tests ---
+
+func TestQuery_FiltersProjectScope(t *testing.T) {
+	stub := newStub()
+	stub.embedFn = func(texts []string) ([][]float64, error) {
+		results := make([][]float64, len(texts))
+		for i := range texts {
+			results[i] = []float64{0.9, 0.1, 0}
+		}
+		return results, nil
+	}
+	kbase := openTestKB(t, stub)
+
+	addAndPromoteWithScope(t, kbase, "User visible", "src", "manual", []float64{0.9, 0.1, 0}, "user", "")
+	addAndPromoteWithScope(t, kbase, "Project A only", "src", "manual", []float64{0.9, 0.1, 0}, "project", "project-a")
+	addAndPromoteWithScope(t, kbase, "Project B only", "src", "manual", []float64{0.9, 0.1, 0}, "project", "project-b")
+
+	results, err := kbase.Query("search", "")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result (user-scoped only), got %d", len(results))
+	}
+
+	results, err = kbase.Query("search", "project-a")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results (user + project-a), got %d", len(results))
+	}
+}
+
+func addAndPromoteWithScope(t *testing.T, kbase *KnowledgeBase, content, source, sourceType string, emb []float64, scope, project string) string {
+	t.Helper()
+	result, err := kbase.AddStatement(content, source, sourceType, scope, project)
+	if err != nil {
+		t.Fatalf("AddStatement: %v", err)
+	}
+	if emb != nil {
+		blob := embeddingToBlob(emb)
+		_, err = kbase.db.Exec(
+			`UPDATE statements SET embedding = ?, model = ?, status = 'active' WHERE id = ?`,
+			blob, kbase.embeddingModel, result.ID,
+		)
+		if err != nil {
+			t.Fatalf("manual promote: %v", err)
+		}
+	}
+	return result.ID
+}
+
+// --- Soft-delete workflow tests (flag → hidden → restore → visible) ---
+
+func TestFlaggedStatementIsHiddenFromQueries(t *testing.T) {
+	stub := newStub()
+	stub.embedFn = func(texts []string) ([][]float64, error) {
+		results := make([][]float64, len(texts))
+		for i := range texts {
+			results[i] = []float64{0.9, 0.1, 0}
+		}
+		return results, nil
+	}
+	kbase := openTestKB(t, stub)
+
+	id := addAndPromote(t, kbase, "Visible statement", "src", "manual", []float64{0.9, 0.1, 0})
+
+	results, _ := kbase.Query("Visible", "")
+	if len(results) != 1 {
+		t.Fatalf("precondition: expected statement to be queryable")
+	}
+
+	kbase.FlagStatement(id)
+	results, _ = kbase.Query("Visible", "")
+	if len(results) != 0 {
+		t.Errorf("flagged statement should be hidden from queries, got %d results", len(results))
+	}
+}
+
+func TestRestoredStatementBecomesQueryableAgain(t *testing.T) {
+	stub := newStub()
+	stub.embedFn = func(texts []string) ([][]float64, error) {
+		results := make([][]float64, len(texts))
+		for i := range texts {
+			results[i] = []float64{0.9, 0.1, 0}
+		}
+		return results, nil
+	}
+	kbase := openTestKB(t, stub)
+
+	id := addAndPromote(t, kbase, "Will restore", "src", "manual", []float64{0.9, 0.1, 0})
+	kbase.FlagStatement(id)
+
+	results, _ := kbase.Query("restore", "")
+	if len(results) != 0 {
+		t.Fatalf("precondition: flagged statement should be hidden")
+	}
+
+	kbase.RestoreStatement(id)
+	results, _ = kbase.Query("restore", "")
+	if len(results) != 1 {
+		t.Errorf("restored statement should be queryable, got %d results", len(results))
+	}
+}
+
+func TestConfirmDeleteRemovesStatementPermanently(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	result, _ := kbase.AddStatement("To be deleted", "src", "manual", "", "")
+	kbase.FlagStatement(result.ID)
+
+	flagged, _ := kbase.ListFlaggedStatements()
+	if len(flagged) != 1 {
+		t.Fatalf("precondition: expected 1 flagged statement")
+	}
+
+	err := kbase.DeleteStatement(result.ID)
+	if err != nil {
+		t.Fatalf("DeleteStatement: %v", err)
+	}
+
+	flagged, _ = kbase.ListFlaggedStatements()
+	if len(flagged) != 0 {
+		t.Errorf("deleted statement should not appear in flagged list")
+	}
+
+	_, err = kbase.GetStatement(result.ID)
+	if err == nil {
+		t.Error("statement should be permanently deleted")
+	}
+}
+
+// --- truncateRunes tests ---
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		input    string
+		limit    int
+		expected string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 3, "hel..."},
+		{"", 5, ""},
+		{"日本語テスト", 3, "日本語..."},
+		{"日本語テスト", 10, "日本語テスト"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := truncateRunes(tt.input, tt.limit)
+			if got != tt.expected {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- ResolveIssue error cases ---
+
+func TestResolveIssue_NotFound(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	err := kbase.ResolveIssue("nonexistent-id", "keep_a")
+	if err == nil {
+		t.Fatal("expected error for nonexistent issue")
+	}
+}
+
+func TestResolveIssue_AlreadyResolved(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	now := time.Now().Format("2006-01-02")
+	kbase.db.Exec(`INSERT INTO statements (id, content, source, source_type, status, created_at) VALUES (?, ?, '', 'manual', 'active', ?)`, "stmt-ar-a", "A", now)
+	kbase.db.Exec(`INSERT INTO statements (id, content, source, source_type, status, created_at) VALUES (?, ?, '', 'manual', 'active', ?)`, "stmt-ar-b", "B", now)
+
+	issueNow := time.Now().Format("2006-01-02T15:04:05Z")
+	kbase.db.Exec(`INSERT INTO issues (id, type, status, statement_a, statement_b, score, created_at, resolved_at) VALUES (?, 'duplicate', 'resolved', ?, ?, 0.9, ?, ?)`, "iss-ar", "stmt-ar-a", "stmt-ar-b", issueNow, issueNow)
+
+	err := kbase.ResolveIssue("iss-ar", "keep_a")
+	if err == nil {
+		t.Fatal("expected error for already resolved issue")
+	}
+}
+
+func TestResolveIssue_UnknownAction(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	now := time.Now().Format("2006-01-02")
+	kbase.db.Exec(`INSERT INTO statements (id, content, source, source_type, status, created_at) VALUES (?, ?, '', 'manual', 'pending', ?)`, "stmt-ua-a", "A", now)
+	kbase.db.Exec(`INSERT INTO statements (id, content, source, source_type, status, created_at) VALUES (?, ?, '', 'manual', 'pending', ?)`, "stmt-ua-b", "B", now)
+
+	issueNow := time.Now().Format("2006-01-02T15:04:05Z")
+	kbase.db.Exec(`INSERT INTO issues (id, type, status, statement_a, statement_b, score, created_at) VALUES (?, 'duplicate', 'open', ?, ?, 0.9, ?)`, "iss-ua", "stmt-ua-a", "stmt-ua-b", issueNow)
+
+	err := kbase.ResolveIssue("iss-ua", "invalid_action")
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+}
+
+// --- PromoteStatement and DeleteStatement error cases ---
+
+func TestPromoteStatement_NotFound(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	err := kbase.PromoteStatement("nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent statement")
+	}
+}
+
+func TestDeleteStatement_NotFound(t *testing.T) {
+	stub := newStub()
+	kbase := openTestKB(t, stub)
+
+	err := kbase.DeleteStatement("nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent statement")
+	}
+}

--- a/internal/kb/kb_test.go
+++ b/internal/kb/kb_test.go
@@ -57,7 +57,7 @@ func openTestKB(t *testing.T, stub *stubModel) *KnowledgeBase {
 // with an embedding, simulating what the worker would do.
 func addAndPromote(t *testing.T, kbase *KnowledgeBase, content, source, sourceType string, emb []float64) string {
 	t.Helper()
-	result, err := kbase.AddStatement(content, source, sourceType)
+	result, err := kbase.AddStatement(content, source, sourceType, "user", "")
 	if err != nil {
 		t.Fatalf("AddStatement: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestAddStatement_CreatesRow(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, err := kbase.AddStatement("Test Statement. Some content", "file.go", "manual")
+	result, err := kbase.AddStatement("Test Statement. Some content", "file.go", "manual", "", "")
 	if err != nil {
 		t.Fatalf("AddStatement: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestAddStatement_NoEmbeddingAtInsert(t *testing.T) {
 	}
 	kbase := openTestKB(t, stub)
 
-	result, err := kbase.AddStatement("Embedded content", "src", "")
+	result, err := kbase.AddStatement("Embedded content", "src", "", "", "")
 	if err != nil {
 		t.Fatalf("AddStatement: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestAddStatement_DefaultSourceType(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, err := kbase.AddStatement("Default ST content", "src", "")
+	result, err := kbase.AddStatement("Default ST content", "src", "", "", "")
 	if err != nil {
 		t.Fatalf("AddStatement: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestGetStatement(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Get Test. Content here", "file.go", "manual")
+	result, _ := kbase.AddStatement("Get Test. Content here", "file.go", "manual", "", "")
 
 	s, err := kbase.GetStatement(result.ID)
 	if err != nil {
@@ -220,7 +220,7 @@ func TestTouchStatement(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Touch Test body", "src", "manual")
+	result, _ := kbase.AddStatement("Touch Test body", "src", "manual", "", "")
 
 	err := kbase.TouchStatement(result.ID)
 	if err != nil {
@@ -250,7 +250,7 @@ func TestPromoteStatement(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Promote me", "src", "manual")
+	result, _ := kbase.AddStatement("Promote me", "src", "manual", "", "")
 
 	var status string
 	kbase.db.QueryRow(`SELECT status FROM statements WHERE id = ?`, result.ID).Scan(&status)
@@ -273,7 +273,7 @@ func TestDeleteStatement(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Delete me", "src", "manual")
+	result, _ := kbase.AddStatement("Delete me", "src", "manual", "", "")
 
 	err := kbase.DeleteStatement(result.ID)
 	if err != nil {
@@ -292,7 +292,7 @@ func TestQuery_EmptyDB(t *testing.T) {
 	stub := newStub()
 	kbase := openTestKB(t, stub)
 
-	results, err := kbase.Query("anything")
+	results, err := kbase.Query("anything", "")
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestQuery_FindsSimilarStatements(t *testing.T) {
 	addAndPromote(t, kbase, "Go Pointers. How Go pointers work", "docs", "manual", []float64{0.9, 0.1, 0})
 	addAndPromote(t, kbase, "Pasta Recipe. How to cook pasta", "cookbook", "manual", []float64{0, 0.1, 0.9})
 
-	results, err := kbase.Query("Go programming")
+	results, err := kbase.Query("Go programming", "")
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestQuery_RespectsThreshold(t *testing.T) {
 	// Add with orthogonal embedding (dot product with query ≈ 0)
 	addAndPromote(t, kbase, "Orthogonal content", "src", "manual", []float64{0, 1, 0})
 
-	results, err := kbase.Query("search query")
+	results, err := kbase.Query("search query", "")
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestQuery_ResultsSortedByScore(t *testing.T) {
 	addAndPromote(t, kbase, "High Relevance high", "src", "manual", []float64{0.95, 0.05, 0})
 	addAndPromote(t, kbase, "Medium Relevance medium", "src", "manual", []float64{0.7, 0.3, 0})
 
-	results, err := kbase.Query("search")
+	results, err := kbase.Query("search", "")
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestQuery_ContentTruncated(t *testing.T) {
 	longContent := strings.Repeat("x", 300)
 	addAndPromote(t, kbase, "Long Content. "+longContent, "src", "manual", []float64{0.5, 0.5, 0})
 
-	results, err := kbase.Query("Long Content")
+	results, err := kbase.Query("Long Content", "")
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestAddStatement_RejectsTooLarge(t *testing.T) {
 	kbase := openTestKB(t, stub)
 
 	large := strings.Repeat("x", MaxStatementSize+1)
-	_, err := kbase.AddStatement(large, "src", "manual")
+	_, err := kbase.AddStatement(large, "src", "manual", "", "")
 	if err == nil {
 		t.Fatal("expected error for oversized statement")
 	}
@@ -474,7 +474,7 @@ func TestAddStatement_AcceptsExactLimit(t *testing.T) {
 	kbase := openTestKB(t, stub)
 
 	exact := strings.Repeat("x", MaxStatementSize)
-	result, err := kbase.AddStatement(exact, "src", "manual")
+	result, err := kbase.AddStatement(exact, "src", "manual", "", "")
 	if err != nil {
 		t.Fatalf("expected no error at exact limit, got %v", err)
 	}
@@ -492,7 +492,7 @@ func TestAddStatement_EmbeddingFailure(t *testing.T) {
 	}
 	kbase := openTestKB(t, stub)
 
-	result, err := kbase.AddStatement("Survives embedding failure", "src", "manual")
+	result, err := kbase.AddStatement("Survives embedding failure", "src", "manual", "", "")
 	if err != nil {
 		t.Fatalf("AddStatement should succeed even when embedding fails: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestAddStatement_EmbeddingFailure(t *testing.T) {
 	}
 
 	// Query should not crash on an empty/NULL-embedding DB
-	results, err := kbase.Query("anything")
+	results, err := kbase.Query("anything", "")
 	if err != nil {
 		t.Fatalf("Query should not error: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestWorker_PromotesPendingStatement(t *testing.T) {
 	}
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Worker test content", "src", "manual")
+	result, _ := kbase.AddStatement("Worker test content", "src", "manual", "", "")
 
 	// Run one processing cycle
 	ctx, cancel := context.WithCancel(context.Background())
@@ -570,8 +570,8 @@ func TestWorker_CreatesIssueForDuplicates(t *testing.T) {
 	kbase := openTestKB(t, stub)
 
 	// Add two near-identical statements
-	r1, _ := kbase.AddStatement("Statement one", "src", "manual")
-	r2, _ := kbase.AddStatement("Statement two", "src", "manual")
+	r1, _ := kbase.AddStatement("Statement one", "src", "manual", "", "")
+	r2, _ := kbase.AddStatement("Statement two", "src", "manual", "", "")
 
 	// Process both
 	ctx, cancel := context.WithCancel(context.Background())
@@ -622,7 +622,7 @@ func TestWorker_SkipsOnEmbeddingFailure(t *testing.T) {
 	}
 	kbase := openTestKB(t, stub)
 
-	result, _ := kbase.AddStatement("Stuck without embedding", "src", "manual")
+	result, _ := kbase.AddStatement("Stuck without embedding", "src", "manual", "", "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/kb/migrate.go
+++ b/internal/kb/migrate.go
@@ -39,6 +39,8 @@ func migrate(db *sql.DB) error {
 	// Migrations: add columns to existing tables
 	migrations := []string{
 		`ALTER TABLE statements ADD COLUMN flagged_at TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE statements ADD COLUMN scope TEXT NOT NULL DEFAULT 'user'`,
+		`ALTER TABLE statements ADD COLUMN project TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {

--- a/internal/kb/migrate.go
+++ b/internal/kb/migrate.go
@@ -36,6 +36,16 @@ func migrate(db *sql.DB) error {
 		}
 	}
 
+	// Migrations: add columns to existing tables
+	migrations := []string{
+		`ALTER TABLE statements ADD COLUMN flagged_at TEXT NOT NULL DEFAULT ''`,
+	}
+
+	for _, m := range migrations {
+		// Ignore errors — column may already exist
+		db.Exec(m)
+	}
+
 	return nil
 }
 

--- a/internal/kb/query.go
+++ b/internal/kb/query.go
@@ -8,7 +8,8 @@ import (
 
 // Query performs brute-force KNN search over active statement embeddings.
 // Returns results sorted by cosine similarity descending, filtered by threshold.
-func (kb *KnowledgeBase) Query(query string) ([]QueryResult, error) {
+// Results include user-scoped statements and project-scoped statements matching the project.
+func (kb *KnowledgeBase) Query(query, project string) ([]QueryResult, error) {
 	// Embed the query
 	queryEmb, err := kb.embedText(query)
 	if err != nil {
@@ -17,11 +18,13 @@ func (kb *KnowledgeBase) Query(query string) ([]QueryResult, error) {
 	}
 
 	// Load all active statement embeddings matching the current model
+	// Include user-scoped statements and project-scoped statements for this project
 	rows, err := kb.db.Query(
 		`SELECT id, content, source, last_verified, embedding
 		 FROM statements
-		 WHERE status = 'active' AND embedding IS NOT NULL AND model = ? AND flagged_at = ''`,
-		kb.embeddingModel,
+		 WHERE status = 'active' AND embedding IS NOT NULL AND model = ? AND flagged_at = ''
+		   AND (scope = 'user' OR (scope = 'project' AND project = ?))`,
+		kb.embeddingModel, project,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query statements: %w", err)

--- a/internal/kb/query.go
+++ b/internal/kb/query.go
@@ -20,7 +20,7 @@ func (kb *KnowledgeBase) Query(query string) ([]QueryResult, error) {
 	rows, err := kb.db.Query(
 		`SELECT id, content, source, last_verified, embedding
 		 FROM statements
-		 WHERE status = 'active' AND embedding IS NOT NULL AND model = ?`,
+		 WHERE status = 'active' AND embedding IS NOT NULL AND model = ? AND flagged_at = ''`,
 		kb.embeddingModel,
 	)
 	if err != nil {

--- a/internal/kb/statement.go
+++ b/internal/kb/statement.go
@@ -41,7 +41,8 @@ type AddStatementResult struct {
 
 // AddStatement creates a new statement with status "pending" and no embedding.
 // The background worker will compute the embedding and promote the statement.
-func (kb *KnowledgeBase) AddStatement(statement, source, sourceType string) (*AddStatementResult, error) {
+// Scope must be "user" or "project". Project is only used when scope is "project".
+func (kb *KnowledgeBase) AddStatement(statement, source, sourceType, scope, project string) (*AddStatementResult, error) {
 	if len(statement) > MaxStatementSize {
 		return nil, ErrStatementTooLarge
 	}
@@ -50,19 +51,23 @@ func (kb *KnowledgeBase) AddStatement(statement, source, sourceType string) (*Ad
 		sourceType = "manual"
 	}
 
+	if scope == "" {
+		scope = "user"
+	}
+
 	id := newStatementID()
 	now := time.Now().Format("2006-01-02")
 
 	_, err := kb.db.Exec(
-		`INSERT INTO statements (id, content, source, source_type, status, embedding, model, created_at, last_verified)
-		 VALUES (?, ?, ?, ?, 'pending', NULL, '', ?, ?)`,
-		id, statement, source, sourceType, now, now,
+		`INSERT INTO statements (id, content, source, source_type, status, embedding, model, created_at, last_verified, scope, project)
+		 VALUES (?, ?, ?, ?, 'pending', NULL, '', ?, ?, ?, ?)`,
+		id, statement, source, sourceType, now, now, scope, project,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert statement: %w", err)
 	}
 
-	slog.Info("statement added (pending)", "id", id, "content", truncateRunes(statement, 80))
+	slog.Info("statement added (pending)", "id", id, "scope", scope, "content", truncateRunes(statement, 80))
 
 	// Notify worker (non-blocking)
 	select {

--- a/internal/kb/statement.go
+++ b/internal/kb/statement.go
@@ -131,6 +131,41 @@ func (kb *KnowledgeBase) TouchStatement(id string) error {
 	return nil
 }
 
+// FlagStatement marks a statement for deletion review.
+func (kb *KnowledgeBase) FlagStatement(id string) error {
+	now := time.Now().Format("2006-01-02T15:04:05Z")
+	result, err := kb.db.Exec(
+		`UPDATE statements SET flagged_at = ? WHERE id = ? AND flagged_at = ''`,
+		now, id,
+	)
+	if err != nil {
+		return fmt.Errorf("flag statement: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("statement not found or already flagged: %s", id)
+	}
+	slog.Info("statement flagged for deletion", "id", id)
+	return nil
+}
+
+// RestoreStatement clears the flagged_at timestamp.
+func (kb *KnowledgeBase) RestoreStatement(id string) error {
+	result, err := kb.db.Exec(
+		`UPDATE statements SET flagged_at = '' WHERE id = ? AND flagged_at != ''`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("restore statement: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("statement not found or not flagged: %s", id)
+	}
+	slog.Info("statement restored", "id", id)
+	return nil
+}
+
 // newStatementID generates a UUID v4 for statement IDs.
 func newStatementID() string {
 	var b [16]byte


### PR DESCRIPTION
## Summary

- Add `kb_forget` MCP tool for soft-deleting statements (flagged for user review)
- Extend issues UI with a second tab for reviewing flagged statements
- Add scope (user/project) to KB statements for better isolation

## Changes

### Commit 1: Add kb_forget MCP tool with soft-delete
- `flagged_at` column for soft-delete semantics
- `FlagStatement` / `RestoreStatement` methods
- `ListFlaggedStatements` for UI display
- Flagged statements hidden from `kb_query` results

### Commit 2: Extend issues UI for flagged statements
- `/api/kb/flagged`, `/api/kb/flagged/confirm`, `/api/kb/flagged/restore` endpoints
- Tabbed interface in issue resolver (Tab or ←→ to switch)
- `d` (confirm delete) and `r` (restore) actions

### Commit 3: Add scope to knowledge base
- `scope` and `project` columns
- Query filtering: user-scoped always visible, project-scoped only when matching
- `kb_remember` accepts scope parameter
- Improved prompts and tool descriptions

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -d .` (no output)